### PR TITLE
docs: clarify Lambda packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,8 @@ cd aws-energy-data-pipeline
 export ENERGY_BUCKET_NAME=your-bucket-name
 ```
 
-### 4. Zip Lambda Files
-```bash
-cd lambda && zip lambda_function.zip lambda_function.py && cd ..
-cd data_generator && zip generate_data.zip generate_data.py && cd ..
-```
+### 4. Lambda Packaging
+Terraform automatically creates the Lambda zip files during `terraform apply`, so manual zipping is unnecessary.
 
 ### 5. Deploy Infrastructure
 ```bash


### PR DESCRIPTION
## Summary
- mention Terraform auto packages Lambda files in README
- remove manual zip commands from setup instructions

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684716c067348322a3bb02724c396b32