### PR TITLE
fix: use consistent DynamoDB table name

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,5 +7,5 @@ variable "s3_bucket" {
 }
 
 variable "dynamodb_table" {
-  default = "Energy_Data_Info"
+  default = "EnergyData"
 }


### PR DESCRIPTION
## Summary
- standardize DynamoDB table name

## Testing
- `terraform fmt` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684716bdc7e48322a11b6aa8cdee05ec