### PR TITLE
Add random suffix to S3 bucket

### DIFF
--- a/terraform/random.tf
+++ b/terraform/random.tf
@@ -1,0 +1,5 @@
+resource "random_string" "s3_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "energy_data" {
-  bucket = var.s3_bucket
+  bucket = "${var.s3_bucket}-${random_string.s3_suffix.result}"
   force_destroy = true
 }
 


### PR DESCRIPTION
## Summary
- make the S3 bucket unique on each deploy by concatenating a random string
- add random string Terraform resource

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684713b430e08322907375200e3fa92f